### PR TITLE
Fixing version reporting from executable

### DIFF
--- a/bin/swift
+++ b/bin/swift
@@ -1047,7 +1047,12 @@ OS_TENANT_NAME OS_TENANT_ID to be set or overridden with --os-auth-url,
 
 
 if __name__ == '__main__':
-    parser = OptionParser(version='%prog 1.0', usage='''
+    try:
+      from swiftclient.version import version_info
+      version_str = version_info.deferred_version_string('%prog ')
+    except IOError:
+      version_str = '%prog (unknown version)'
+    parser = OptionParser(version=version_str, usage='''
 Usage: %%prog <command> [options] [args]
 
 Commands:

--- a/swiftclient/openstack/common/version.py
+++ b/swiftclient/openstack/common/version.py
@@ -31,6 +31,10 @@ class _deferred_version_string(object):
         self.version_info = version_info
         self.prefix = prefix
 
+    def __getattr__(self, method_name):
+        """Delegate to the generated string"""
+        return getattr(self.__str__(), method_name)
+
     def __str__(self):
         return "%s%s" % (self.prefix, self.version_info.version_string())
 


### PR DESCRIPTION
Rather confusingly, `swift --version` always returns `swift 1.0`.

This patch fixes the issue by using the internal version API. By using deferred version generation, it adds no extra overhead (other than module inclusion) unless `--version` is specified.
