### PR TITLE
Stop loss of precision when writing 'x-object-meta-mtime' 

### DIFF
--- a/bin/swift
+++ b/bin/swift
@@ -807,7 +807,7 @@ def st_upload(parser, args, print_queue, error_queue):
                 obj = obj[2:]
             if obj.startswith('/'):
                 obj = obj[1:]
-            put_headers = {'x-object-meta-mtime': str(getmtime(path))}
+            put_headers = {'x-object-meta-mtime': "%f" % getmtime(path)}
             if dir_marker:
                 if options.changed:
                     try:


### PR DESCRIPTION
Stop loss of precision when writing 'x-object-meta-mtime' 

str(float) isn't a good way of converting a float to a string with all the precision

Eg

```
>>> f = os.path.getmtime("z")
>>> f
1347717491.343554
>>> str(f)
'1347717491.34'
>>> "%f" % f
'1347717491.343554'
```
