### PR TITLE
should be set_tunnel and not _set_tunnel

### DIFF
--- a/swiftclient/client.py
+++ b/swiftclient/client.py
@@ -181,7 +181,7 @@ def http_connection(url, proxy=None):
         return request_escaped
     conn.request = request_wrapper(conn.request)
     if proxy:
-        conn._set_tunnel(parsed.hostname, parsed.port)
+        conn.set_tunnel(parsed.hostname, parsed.port)
     return parsed, conn
 
 


### PR DESCRIPTION
http://docs.python.org/2/library/httplib.html

The docs and a bug report on #openstack-swift seem to indicate this should be set_tunnel and not _set_tunnel.
