### PR TITLE
Add close to swiftclient.client.Connection

### DIFF
--- a/swiftclient/client.py
+++ b/swiftclient/client.py
@@ -1071,7 +1071,7 @@ class Connection(object):
         self.ssl_compression = ssl_compression
 
     def close(self):
-        if self.http_conn and self.http_conn is tuple\
+        if self.http_conn and type(self.http_conn) is tuple\
                 and len(self.http_conn) > 1:
             conn = self.http_conn[1]
             if hasattr(conn, 'close') and callable(conn.close):


### PR DESCRIPTION
The swiftclient.client.Connection does not have a close method. It may keep many socket connections if we don not close them.
