### PR TITLE
"download" written as "downlad" at line 1292

### DIFF
--- a/bin/swift
+++ b/bin/swift
@@ -1289,7 +1289,7 @@ Command-line interface to the OpenStack Swift API.
 Positional arguments:
   <subcommand>
     delete               Delete a container or objects within a container
-    downlad              Download objects from containers
+    download             Download objects from containers
     list                 Lists the containers for the account or the objects
                          for a container
     post                 Updates meta information for the account, container,


### PR DESCRIPTION
in the Help part at line 1292
"downlad             Download objects from containers"
changed to 
"download             Download objects from containers"
