### PR TITLE
generate Windows exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr'],
-    pbr=True)
+    pbr=True,
+    entry_points={
+        "console_scripts": [
+            "swift=swiftclient.shell:main"
+        ]
+    })


### PR DESCRIPTION
Now bin\swift can only be started by `python Scripts\swift`.
(Windows does not support extensionless scripts)
Maybe I did it wrong, this is my first encounter with distutil.
