### PR TITLE
Avoid nuking "Content-Type" in headers.

### DIFF
--- a/swiftclient/client.py
+++ b/swiftclient/client.py
@@ -970,7 +970,7 @@ def put_object(url, token=None, container=None, name=None, contents=None,
     if content_type is not None:
         headers['Content-Type'] = content_type
     else:  # python-requests sets application/x-www-form-urlencoded otherwise
-        headers['Content-Type'] = ''
+        headers.setdefault('Content-Type','')
     if not contents:
         headers['Content-Length'] = '0'
     if hasattr(contents, 'read'):


### PR DESCRIPTION
Basically, if I already provide a value for "Content-Type" as part of the `headers` argument, don't replace it silently by the empty string.
