### PR TITLE
Error in the docstring

### DIFF
--- a/swiftclient/service.py
+++ b/swiftclient/service.py
@@ -1157,7 +1157,7 @@ class SwiftService(object):
 
                             {
                                 'meta': [],
-                                'headers': [],
+                                'header': [],
                                 'segment_size': None,
                                 'use_slo': False,
                                 'segment_container: None,


### PR DESCRIPTION
I noticed an error in the docstring of the method "upload".
The key of the dictionary (options) for headers is header and not headers.