### PR TITLE
put_object(): Do not overwrite 'Content-Type' if it's already present in headers

### DIFF
--- a/swiftclient/client.py
+++ b/swiftclient/client.py
@@ -1074,7 +1074,7 @@ def put_object(url, token=None, container=None, name=None, contents=None,
                 content_length = int(v)
     if content_type is not None:
         headers['Content-Type'] = content_type
-    else:  # python-requests sets application/x-www-form-urlencoded otherwise
+    elif 'Content-Type' not in headers:  # python-requests sets application/x-www-form-urlencoded otherwise
         headers['Content-Type'] = ''
     if not contents:
         headers['Content-Length'] = '0'


### PR DESCRIPTION
This fixes ability to set a custom 'Content-Type' via -H option to
the "swift upload" command which was broken by the commit
258420f41049d92fc0b59b9263c8381bfe513432