### PR TITLE
Allow _retry to continue if there's an SSLError in --insecure mode.

### DIFF
--- a/swiftclient/client.py
+++ b/swiftclient/client.py
@@ -1673,8 +1673,12 @@ class Connection(object):
                           service_token=self.service_token, **kwargs)
                 self._add_response_dict(caller_response_dict, kwargs)
                 return rv
-            except SSLError:
-                raise
+            except SSLError as err:
+                if self.insecure is True:
+                    logger.warning('caught SSLError: ' + err)
+                    pass
+                else:
+                    raise
             except (socket.error, RequestException):
                 self._add_response_dict(caller_response_dict, kwargs)
                 if self.attempts > self.retries:


### PR DESCRIPTION
The existing code was throwing an exception instead of continueing to the next
retry. That may be the proper thing to do for a CertificateError, but SSLError
can also be raised on a connection reset.

The existing logic was very problematic when uploading a large file with many
segments. If one segment has a connection reset, the code would stop attempting
to upload that segment, but swiftclient would wait for the rest of the segments
to complete before getting the results of all the futures and refusing to
create the manifest.

Ideally, the exception handling would be further improved to only "raise" a
CertificateError. With this commit, at least there's a workaround for users that
are OK with --insecure mode, and need to upload large files.