### PR TITLE
Fix failure to update object when permission to manage containers is missing

### DIFF
--- a/swiftclient/service.py
+++ b/swiftclient/service.py
@@ -1454,6 +1454,9 @@ class SwiftService(object):
         # to HEAD the first container
         for r in interruptable_as_completed(create_containers):
             res = r.result()
+            # Explicitly ignore failure to create container because of missing permission
+            if 'error' in res and res['error'].http_status == 405:
+                continue
             yield res
 
         if segment_size:


### PR DESCRIPTION
Fixes the root cause for https://bugs.launchpad.net/python-swiftclient/+bug/1204558 and https://bugs.launchpad.net/python-swiftclient/+bug/1110914.

According to [this comment](https://github.com/openstack/python-swiftclient/blob/master/swiftclient/service.py#L1438) the missing permission for PUT on containers should be ignored. However this is not the case: when this permission is missing the whole job is [marked as failed](https://github.com/openstack/python-swiftclient/blob/master/swiftclient/service.py#L1646).

This use case is critical for cloud environments where Swift containers are managed by cloud services provider and not by user.